### PR TITLE
Update YQ version to 4.49.2-r6 in Dockerfile

### DIFF
--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -7,7 +7,7 @@ ENV S6_VERBOSITY="1"
 ARG BUILD_ARCH="amd64"
 
 # renovate: datasource=repology depName=yq packageName=alpine_3_22/yq-go versioning=loose
-ARG YQ_VERSION="4.49.2-r5"
+ARG YQ_VERSION="4.49.2-r6"
 # renovate: datasource=github-releases depName=cloudflared packageName=cloudflare/cloudflared versioning=loose
 ARG CLOUDFLARED_VERSION="2026.5.0"
 


### PR DESCRIPTION
because the live build depends on the pinned Alpine package revision, and yq-go=4.49.2-r5 is no longer available.

# Proposed Changes

- Bump `yq-go` from `4.49.2-r5` to `4.49.2-r6`.
- Restore the Docker build for Home Assistant add-on installations that build from source.
- This also fixes the downstream Caddy variant based on this add-on.

## Related Issues

- None