### PR TITLE
Use official release drafter, as a standalone workflow, without delay

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,15 +171,3 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=edge
-
-  update_release_draft:
-    name: Draft release
-    needs:
-      - build
-    if: github.event_name == 'push' && github.ref_name == github.event.repository.default_branch
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🚀 Run Release Drafter
-        uses: homeassistant-apps/action-release-drafter@v6.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,12 @@
+---
+name: Release Drafter
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  workflows:
+    uses: hassio-addons/workflows/.github/workflows/release-drafter.yaml@main


### PR DESCRIPTION
# Proposed Changes

Should be merged after https://github.com/homeassistant-apps/workflows/pull/33 is merged.

## Related Issues

