### PR TITLE
fix: fix regressions in 7.0.12-13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,6 +119,15 @@ jobs:
         with:
           prettier_options: --write **/*.{json,js,md,yaml}
 
+  test-shell:
+    name: Shell tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@v7
+      - name: 🚀 Run shell test suite
+        run: bash ./cloudflared/tests/test_config_and_set_vars.sh
+
   build:
     name: Build ${{ matrix.architecture }}
     needs:
@@ -130,6 +139,7 @@ jobs:
       - lint-prettier
       - lint-shellcheck
       - lint-yamllint
+      - test-shell
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
@@ -82,8 +82,8 @@ validateConfigAndSetVars() {
     data_path="/data"
 
     bashio::log.debug "Checking Home Assistant port and if SSL is used..."
-    local ha_config_file="/homeassistant/configuration.yaml"
-    local ha_storage_http="/homeassistant/.storage/http"
+    local ha_config_file="${HOMEASSISTANT_CONFIG_FILE:-/homeassistant/configuration.yaml}"
+    local ha_storage_http="${HOMEASSISTANT_STORAGE_HTTP:-/homeassistant/.storage/http}"
     local ha_port="8123"
     local ha_ssl="false"
 
@@ -94,17 +94,54 @@ validateConfigAndSetVars() {
         local ha_ssl_from_storage=""
 
         if [[ -f "${ha_storage_http}" ]]; then
-            ha_port_from_storage=$(yq '.data.stable.server_port' "${ha_storage_http}" 2>/dev/null || true)
-            ha_ssl_from_storage=$(yq '.data.stable | (has("ssl_certificate") and has("ssl_key"))' "${ha_storage_http}" 2>/dev/null || true)
+            local storage_base=".data"
+            local storage_version=""
+            storage_version=$(yq '.version' "${ha_storage_http}" 2>/dev/null || true)
+            case "${storage_version}" in
+                1)
+                    storage_base=".data"
+                    ;;
+                2)
+                    storage_base=".data.stable"
+                    ;;
+                *)
+                    bashio::log.warning "Unknown Home Assistant storage version '${storage_version}' in ${ha_storage_http}, falling back to version 2 behavior"
+                    storage_base=".data.stable"
+                    ;;
+            esac
+
+            ha_port_from_storage=$(yq "${storage_base}.server_port" "${ha_storage_http}" 2>/dev/null || true)
+            local ha_ssl_from_storage=""
+            local ha_ssl_cert_from_storage=""
+            local ha_ssl_key_from_storage=""
+            local storage_is_map=""
+            storage_is_map=$(yq "${storage_base} | select(type == \"!!map\")" "${ha_storage_http}" 2>/dev/null || true)
+
+            if [[ -n "${storage_is_map}" ]]; then
+                ha_ssl_cert_from_storage=$(yq "${storage_base}.ssl_certificate" "${ha_storage_http}" 2>/dev/null || true)
+                ha_ssl_key_from_storage=$(yq "${storage_base}.ssl_key" "${ha_storage_http}" 2>/dev/null || true)
+
+                if [[ -n "${ha_ssl_cert_from_storage}" || -n "${ha_ssl_key_from_storage}" ]]; then
+                    if [[ "${ha_ssl_cert_from_storage}" != "null" && -n "${ha_ssl_cert_from_storage}" ]] && \
+                        [[ "${ha_ssl_key_from_storage}" != "null" && -n "${ha_ssl_key_from_storage}" ]]; then
+                        ha_ssl_from_storage="true"
+                        bashio::log.debug "Read Home Assistant SSL from ${ha_storage_http}: ${ha_ssl_from_storage}"
+                    else
+                        ha_ssl_from_storage="false"
+                        bashio::log.debug "Read Home Assistant SSL from ${ha_storage_http}: ${ha_ssl_from_storage}"
+                    fi
+                fi
+            fi
 
             if [[ -n "${ha_port_from_storage}" && "${ha_port_from_storage}" != "null" ]]; then
                 ha_port="${ha_port_from_storage}"
                 bashio::log.debug "Read Home Assistant port from ${ha_storage_http}: ${ha_port}"
             fi
 
-            if [[ -n "${ha_ssl_from_storage}" && "${ha_ssl_from_storage}" != "null" ]]; then
-                ha_ssl="${ha_ssl_from_storage}"
-                bashio::log.debug "Read Home Assistant SSL from ${ha_storage_http}: ${ha_ssl}"
+            if [[ "${ha_ssl_from_storage}" == "true" ]]; then
+                ha_ssl="true"
+            elif [[ "${ha_ssl_from_storage}" == "false" ]]; then
+                ha_ssl="false"
             fi
         fi
 
@@ -433,4 +470,7 @@ main() {
 
     bashio::log.info "Finished setting up the Cloudflare Tunnel"
 }
-main "$@"
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/cloudflared/tests/bashio-mocks.sh
+++ b/cloudflared/tests/bashio-mocks.sh
@@ -1,0 +1,75 @@
+# Bashio helper mocks used for local shell unit tests.
+# This file is intended to be sourced by shell test harnesses.
+
+declare -Ag TEST_CONFIG
+TEST_CONFIG=()
+
+bashio::log.trace() { :; }
+bashio::log.info() { :; }
+bashio::log.debug() { :; }
+bashio::log.notice() { :; }
+bashio::log.warning() { :; }
+bashio::log.error() { :; }
+
+bashio::config.has_value() {
+    local key="$1"
+    [[ -n "${TEST_CONFIG[$key]:-}" ]]
+}
+
+bashio::config.is_empty() {
+    local key="$1"
+    [[ -z "${TEST_CONFIG[$key]:-}" ]]
+}
+
+bashio::config.exists() {
+    local key="$1"
+    [[ -v TEST_CONFIG[$key] ]]
+}
+
+bashio::config.true() {
+    local key="$1"
+    local value="${TEST_CONFIG[$key]:-}"
+    case "${value}" in
+        true|1|TRUE|yes|YES) return 0;;
+        *) return 1;;
+    esac
+}
+
+bashio::config() {
+    local key="$1"
+    printf '%s' "${TEST_CONFIG[$key]:-}"
+}
+
+bashio::addon.config() {
+    printf '%s' "${TEST_ADDON_CONFIG:-{}}"
+}
+
+bashio::var.is_empty() {
+    [[ -z "${1:-}" ]]
+}
+
+bashio::var.true() {
+    case "${1:-}" in
+        true|1|TRUE|yes|YES) return 0;;
+        *) return 1;;
+    esac
+}
+
+bashio::exit.nok() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+bashio::exit.ok() {
+    exit 0
+}
+
+bashio::fs.file_exists() {
+    [[ -f "$1" ]]
+}
+
+bashio::jq() {
+    if [[ $# -gt 0 ]]; then
+        printf '%s' "${1}"
+    fi
+}

--- a/cloudflared/tests/resources/config-basic.yaml
+++ b/cloudflared/tests/resources/config-basic.yaml
@@ -1,0 +1,8 @@
+---
+http:
+  server_port: 443
+  use_x_forwarded_for: true
+  trusted_proxies:
+    - 172.30.33.0/24
+  ssl_certificate: /ssl/fullchain.pem
+  ssl_key: /ssl/privkey.pem

--- a/cloudflared/tests/resources/config-default.yaml
+++ b/cloudflared/tests/resources/config-default.yaml
@@ -1,0 +1,3 @@
+---
+# Loads default set of integrations. Do not remove.
+default_config:

--- a/cloudflared/tests/resources/http-v-1.json
+++ b/cloudflared/tests/resources/http-v-1.json
@@ -1,0 +1,14 @@
+{
+  "version": -1,
+  "minor_version": 2,
+  "key": "http",
+  "data": {
+    "stable": {
+      "server_port": 80,
+      "ssl_certificate": null,
+      "ssl_key": null
+    },
+    "pending": null,
+    "yaml_migration_done": true
+  }
+}

--- a/cloudflared/tests/resources/http-v1-ssl.json
+++ b/cloudflared/tests/resources/http-v1-ssl.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "http",
+  "data": {
+    "server_port": 443,
+    "ssl_certificate": "/ssl/fullchain.pem",
+    "ssl_key": "/ssl/privkey.pem"
+  }
+}

--- a/cloudflared/tests/resources/http-v1.json
+++ b/cloudflared/tests/resources/http-v1.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "minor_version": 1,
+  "key": "http",
+  "data": {
+    "server_port": 80,
+    "ssl_certificate": null,
+    "ssl_key": null
+  }
+}

--- a/cloudflared/tests/resources/http-v2-ssl.json
+++ b/cloudflared/tests/resources/http-v2-ssl.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "minor_version": 2,
+  "key": "http",
+  "data": {
+    "stable": {
+      "use_x_forwarded_for": true,
+      "server_port": 443,
+      "ssl_certificate": "/ssl/fullchain.pem",
+      "ssl_key": "/ssl/privkey.pem",
+      "login_attempts_threshold": -1,
+      "ip_ban_enabled": true,
+      "ssl_profile": "modern",
+      "use_x_frame_options": true,
+      "cors_allowed_origins": ["https://cast.home-assistant.io"],
+      "created_at": "2026-07-30T06:27:37.656162+00:00",
+      "error": null,
+      "error_message": null
+    },
+    "pending": null,
+    "yaml_migration_done": true
+  }
+}

--- a/cloudflared/tests/resources/http-v2.json
+++ b/cloudflared/tests/resources/http-v2.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "minor_version": 2,
+  "key": "http",
+  "data": {
+    "stable": {
+      "use_x_forwarded_for": true,
+      "server_port": 80,
+      "ssl_certificate": null,
+      "ssl_key": null,
+      "login_attempts_threshold": -1,
+      "ip_ban_enabled": true,
+      "ssl_profile": "modern",
+      "use_x_frame_options": true,
+      "cors_allowed_origins": ["https://cast.home-assistant.io"],
+      "created_at": "2026-07-30T06:27:37.656162+00:00",
+      "error": null,
+      "error_message": null
+    },
+    "pending": null,
+    "yaml_migration_done": true
+  }
+}

--- a/cloudflared/tests/test_config_and_set_vars.sh
+++ b/cloudflared/tests/test_config_and_set_vars.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# SC1091: sourced test helpers are loaded dynamically and ShellCheck cannot resolve them here.
+# SC2034: TEST_CONFIG is used via indirect associative-array access in the Bashio mock layer.
+# SC2154: variables like ha_url/tunnel_name are populated by validateConfigAndSetVars in the sourced add-on script.
+# shellcheck disable=SC1091,SC2034,SC2154
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=./bashio-mocks.sh
+source "${ROOT_DIR}/tests/bashio-mocks.sh"
+# shellcheck source=../rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
+source "${ROOT_DIR}/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh"
+
+external_hostname=""
+ha_url=""
+tunnel_name=""
+
+# Basic assertions
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local name="$3"
+
+    if [[ "${actual}" != "${expected}" ]]; then
+        echo "FAIL: ${name}: expected '${expected}', got '${actual}'"
+        exit 1
+    fi
+}
+
+assert() {
+    local condition="$1"
+    local name="$2"
+
+    if ! eval "${condition}"; then
+        echo "FAIL: ${name}"
+        exit 1
+    fi
+}
+
+TEST_FAILURES=0
+
+run_test() {
+    local test_name="$1"
+
+    set +e
+    "${test_name}"
+    local rc=$?
+    set -e
+
+    if [[ ${rc} -ne 0 ]]; then
+        echo "FAIL: ${test_name}"
+        TEST_FAILURES=$((TEST_FAILURES + 1))
+    else
+        echo "PASS: ${test_name}"
+    fi
+}
+
+test_with_storage_http() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant/.storage"
+    cp "${ROOT_DIR}/tests/resources/http-v1.json" "${tmpdir}/homeassistant/.storage/http"
+
+    mkdir -p "${tmpdir}/homeassistant"
+    cp "${ROOT_DIR}/tests/resources/config-basic.yaml" "${tmpdir}/homeassistant/configuration.yaml"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    export HOMEASSISTANT_STORAGE_HTTP="${tmpdir}/homeassistant/.storage/http"
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "http://homeassistant:80" "${ha_url}" "ha_url from storage http"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_storage_http_ssl() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant/.storage"
+    cp "${ROOT_DIR}/tests/resources/http-v1-ssl.json" "${tmpdir}/homeassistant/.storage/http"
+
+    mkdir -p "${tmpdir}/homeassistant"
+    cp "${ROOT_DIR}/tests/resources/config-basic.yaml" "${tmpdir}/homeassistant/configuration.yaml"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    export HOMEASSISTANT_STORAGE_HTTP="${tmpdir}/homeassistant/.storage/http"
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "https://homeassistant:443" "${ha_url}" "ha_url from storage http"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_storage_http_v2() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant/.storage"
+    cp "${ROOT_DIR}/tests/resources/http-v2.json" "${tmpdir}/homeassistant/.storage/http"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    export HOMEASSISTANT_STORAGE_HTTP="${tmpdir}/homeassistant/.storage/http"
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "http://homeassistant:80" "${ha_url}" "ha_url from storage http v2"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_storage_http_v2_ssl() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant/.storage"
+    cp "${ROOT_DIR}/tests/resources/http-v2-ssl.json" "${tmpdir}/homeassistant/.storage/http"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    export HOMEASSISTANT_STORAGE_HTTP="${tmpdir}/homeassistant/.storage/http"
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "https://homeassistant:443" "${ha_url}" "ha_url from storage http v2"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_configuration_yaml_only() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant"
+    cp "${ROOT_DIR}/tests/resources/config-basic.yaml" "${tmpdir}/homeassistant/configuration.yaml"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    unset HOMEASSISTANT_STORAGE_HTTP
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "https://homeassistant:443" "${ha_url}" "ha_url from configuration.yaml"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_default_config_only() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant"
+    cp "${ROOT_DIR}/tests/resources/config-default.yaml" "${tmpdir}/homeassistant/configuration.yaml"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    unset HOMEASSISTANT_STORAGE_HTTP
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "http://homeassistant:8123" "${ha_url}" "ha_url from default_config-only configuration.yaml"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+test_with_unknown_config_version() {
+    local tmpdir
+    tmpdir="$(mktemp -d)"
+
+    mkdir -p "${tmpdir}/homeassistant/.storage"
+    cp "${ROOT_DIR}/tests/resources/http-v-1.json" "${tmpdir}/homeassistant/.storage/http"
+
+    export HOMEASSISTANT_CONFIG_FILE="${tmpdir}/homeassistant/configuration.yaml"
+    export HOMEASSISTANT_STORAGE_HTTP="${tmpdir}/homeassistant/.storage/http"
+
+    TEST_CONFIG=(
+        [external_hostname]="example.com"
+    )
+
+    validateConfigAndSetVars
+
+    assert_eq "http://homeassistant:80" "${ha_url}" "ha_url from unknown storage version"
+    assert_eq "homeassistant" "${tunnel_name}" "default tunnel_name"
+
+    rm -rf "${tmpdir}"
+}
+
+main() {
+    run_test test_with_storage_http
+    run_test test_with_storage_http_ssl
+    run_test test_with_storage_http_v2
+    run_test test_with_storage_http_v2_ssl
+    run_test test_with_configuration_yaml_only
+    run_test test_with_default_config_only
+    run_test test_with_unknown_config_version
+
+    if [[ ${TEST_FAILURES} -ne 0 ]]; then
+        echo "${TEST_FAILURES} test(s) failed."
+        exit 1
+    fi
+
+    echo "All tests passed."
+}
+
+main


### PR DESCRIPTION
# Proposed Changes

Fix regression on pre-2026.8 versions.
Handle unknown storage versions with a warning.
Add a simple bash test suite to guard against any mishaps. 


## Related Issues

fixes #1060 