### PR TITLE
Add Portuguese to cloudfared

### DIFF
--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -9,7 +9,6 @@ ARG BUILD_ARCH="amd64"
 # renovate: datasource=repology depName=yq packageName=alpine_3_22/yq-go versioning=loose
 ARG YQ_VERSION="4.53.3-r0"
 # renovate: datasource=github-releases depName=cloudflared packageName=cloudflare/cloudflared versioning=loose
-# commit to test
 ARG CLOUDFLARED_VERSION="2026.8.3"
 
 # Copy root filesystem

--- a/cloudflared/Dockerfile
+++ b/cloudflared/Dockerfile
@@ -9,6 +9,7 @@ ARG BUILD_ARCH="amd64"
 # renovate: datasource=repology depName=yq packageName=alpine_3_22/yq-go versioning=loose
 ARG YQ_VERSION="4.53.3-r0"
 # renovate: datasource=github-releases depName=cloudflared packageName=cloudflare/cloudflared versioning=loose
+# commit to test
 ARG CLOUDFLARED_VERSION="2026.8.3"
 
 # Copy root filesystem

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -9,7 +9,7 @@ description: "PT translation of
   Use a Cloudflare Tunnel to remotely
   connect to Home Assistant without opening any ports"
 #url: "https://github.com/homeassistant-apps/app-cloudflared"
-urn: "https://github.com/PauloGoncalves86/app-cloudflared"
+url: "https://github.com/PauloGoncalves86/app-cloudflared"
 startup: services
 init: false
 hassio_api: true

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,11 +1,11 @@
 ---
 name: Cloudflared
-version: "2026.8.3-pt1"
+version: "2026.8.3-pt2"
 breaking_versions:
   - 5.3.7
   - 6.0.0
-slug: cloudflared_pt_test
-description: "PT translation of 
+slug: cloudflared_pt_test_2
+description: "PT2 translation of 
   Use a Cloudflare Tunnel to remotely
   connect to Home Assistant without opening any ports"
 #url: "https://github.com/homeassistant-apps/app-cloudflared"

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,6 +1,6 @@
 ---
 name: Cloudflared
-version: dev
+version: prod
 breaking_versions:
   - 5.3.7
   - 6.0.0

--- a/cloudflared/config.yaml
+++ b/cloudflared/config.yaml
@@ -1,13 +1,15 @@
 ---
 name: Cloudflared
-version: prod
+version: "2026.8.3-pt1"
 breaking_versions:
   - 5.3.7
   - 6.0.0
-slug: cloudflared
-description: "Use a Cloudflare Tunnel to remotely
+slug: cloudflared_pt_test
+description: "PT translation of 
+  Use a Cloudflare Tunnel to remotely
   connect to Home Assistant without opening any ports"
-url: "https://github.com/homeassistant-apps/app-cloudflared"
+#url: "https://github.com/homeassistant-apps/app-cloudflared"
+urn: "https://github.com/PauloGoncalves86/app-cloudflared"
 startup: services
 init: false
 hassio_api: true

--- a/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
+++ b/cloudflared/rootfs/etc/s6-overlay/s6-rc.d/prepare/run.sh
@@ -62,7 +62,7 @@ validateConfigAndSetVars() {
 
     # Set and validate 'additional_hosts'
     if bashio::config.has_value 'additional_hosts'; then
-        additional_hosts=$(bashio::jq "$(bashio::addon.config)" ".additional_hosts[]")
+        additional_hosts=$(bashio::jq "$(bashio::app.config)" ".additional_hosts[]")
         readarray -t additional_hosts <<<"${additional_hosts}"
 
         local additional_host

--- a/cloudflared/tests/bashio-mocks.sh
+++ b/cloudflared/tests/bashio-mocks.sh
@@ -40,8 +40,8 @@ bashio::config() {
     printf '%s' "${TEST_CONFIG[$key]:-}"
 }
 
-bashio::addon.config() {
-    printf '%s' "${TEST_ADDON_CONFIG:-{}}"
+bashio::app.config() {
+    printf '%s' "${TEST_APP_CONFIG:-{}}"
 }
 
 bashio::var.is_empty() {

--- a/cloudflared/translations/pt.yaml
+++ b/cloudflared/translations/pt.yaml
@@ -14,7 +14,7 @@ configuration:
     description: >-
       Defina o nome do túnel criado para comunicação entre este
       serviço e o servidor Edge da Cloudflare. O valor por defeito
-      deverá ser adequado na maioria dos casos.
+      deverá ser adequado para a maioria dos casos.
   additional_hosts:
     name: Servidores adicionais
     description: >-

--- a/cloudflared/translations/pt.yaml
+++ b/cloudflared/translations/pt.yaml
@@ -1,47 +1,46 @@
 ---
 configuration:
   log_level:
-    name: Niveau de journalisation
+    name: Nível de logging
     description: >-
-      Définit le niveau de journalisation du module complémentaire.
+      Define o nivel de registo de logging da app.
   external_hostname:
-    name: Nom d'hôte externe de Home Assistant
+    name: Nome externo do seu servidor do  Home Assistant
     description: >-
-      Définissez ceci sur votre nom de domaine ou sous-domaine que
-      vous souhaitez utiliser pour accéder à Home Assistant.
+      Defina aqui o nome com o dominio ou subdominio que
+      pretende utilizar ppara aceder ao seu Home Assistant.
   tunnel_name:
-    name: Nom du tunnel Cloudflare
+    name: Nome do túnel da Cloudflare
     description: >-
-      Définit le nom du tunnel créé pour la communication entre ce
-      service et le serveur Edge de Cloudflare. La valeur par défaut
-      devrait convenir dans la plupart des cas.
+      Defina o nome do túnel criado para comunicação entre este
+      serviço et o servidor Edge da Cloudflare. O valor por defeito
+      deverá ser adequado na maioria dos casos.
   additional_hosts:
-    name: Hôtes supplémentaires
+    name: Servidores adicionais
     description: >-
-      Définissez une liste d'hôtes supplémentaires devant être acheminés
-      par le tunnel Cloudflare.
+      Defina uma lista de servidores adicionais para aceder e encaminhar através do Túnel Cloudflare.
   post_quantum:
-    name: Utiliser la cryptographie post-quantique
+    name: Utilizar criptografia pós-quântica
     description: >-
-      Cochez pour que le tunnel utilise la cryptographie post-quantique.
-      Avertissement : cela restreint également le tunnel au protocole QUIC,
-      ce qui pourrait entraîner des problèmes pour certains utilisateurs.
+      Selecione esta opção para que o túnel utilize criptografia pós-quântica.
+      Aviso: esta opção também restringe o túnel ao protocolo QUIC, o que poderá
+      causar problemas a alguns utilizadores.
   run_parameters:
-    name: Ajouter des paramètres d'exécution
+    name: Adicionar parâmetros de execução
     description: >-
-      Possibilité d'ajouter des paramètres d'exécution à Cloudflared
+      Possibilidade de adicionar parâmetros de execução ao Cloudflared
   catch_all_service:
-    name: Service Catch-All
+    name: Serviço Catch-All
     description: >-
-      Définissez un service Catch-All qui sera appelé pour les services non configurés directement.
+      Define um serviço Catch-All será utilizado para serviços que não estejam configurados diretamente.
   nginx_proxy_manager:
-    name: Activer le service Catch-All de Nginx-Proxy-Manager
+    name: Activar serviço Catch-All do Nginx-Proxy-Manager
     description: >-
-      Définir le service Catch-All sur le module complémentaire "Nginx-Proxy-Manager Community App".
+      Define o serviço Catch-All da app como "Nginx-Proxy-Manager Community App".
   tunnel_token:
-    name: Token du tunnel Cloudflare
+    name: Token do túnel Cloudflare
     description: >-
-      Lorsque cette option est définie, toutes les autres options seront ignorées.
-      Utilisez cette option si vous avez configuré le tunnel via le tableau de bord Cloudflare.
+      Quando esta opção estiver definida, todas as outras opções serão ignoradas.
+      Utilize esta opção se tiver configurado o túnel através do Painel da Cloudflare.
 network:
-  36500/tcp: Interface web des métriques (36500/tcp)
+  36500/tcp: Interface web para as métricas (36500/tcp)

--- a/cloudflared/translations/pt.yaml
+++ b/cloudflared/translations/pt.yaml
@@ -8,12 +8,12 @@ configuration:
     name: Nome externo do seu servidor do  Home Assistant
     description: >-
       Defina aqui o nome com o dominio ou subdominio que
-      pretende utilizar ppara aceder ao seu Home Assistant.
+      pretende utilizar para aceder ao seu Home Assistant.
   tunnel_name:
     name: Nome do túnel da Cloudflare
     description: >-
       Defina o nome do túnel criado para comunicação entre este
-      serviço et o servidor Edge da Cloudflare. O valor por defeito
+      serviço e o servidor Edge da Cloudflare. O valor por defeito
       deverá ser adequado na maioria dos casos.
   additional_hosts:
     name: Servidores adicionais

--- a/cloudflared/translations/pt.yaml
+++ b/cloudflared/translations/pt.yaml
@@ -5,7 +5,7 @@ configuration:
     description: >-
       Define o nivel de registo de logging da app.
   external_hostname:
-    name: Nome externo do seu servidor do  Home Assistant
+    name: Nome externo do seu servidor do Home Assistant
     description: >-
       Defina aqui o nome com o dominio ou subdominio que
       pretende utilizar para aceder ao seu Home Assistant.
@@ -32,7 +32,7 @@ configuration:
   catch_all_service:
     name: Serviço Catch-All
     description: >-
-      Define um serviço Catch-All será utilizado para serviços que não estejam configurados diretamente.
+      Define um serviço Catch-All que será utilizado para serviços que não estejam configurados diretamente.
   nginx_proxy_manager:
     name: Activar serviço Catch-All do Nginx-Proxy-Manager
     description: >-

--- a/cloudflared/translations/pt.yaml
+++ b/cloudflared/translations/pt.yaml
@@ -1,0 +1,47 @@
+---
+configuration:
+  log_level:
+    name: Niveau de journalisation
+    description: >-
+      Définit le niveau de journalisation du module complémentaire.
+  external_hostname:
+    name: Nom d'hôte externe de Home Assistant
+    description: >-
+      Définissez ceci sur votre nom de domaine ou sous-domaine que
+      vous souhaitez utiliser pour accéder à Home Assistant.
+  tunnel_name:
+    name: Nom du tunnel Cloudflare
+    description: >-
+      Définit le nom du tunnel créé pour la communication entre ce
+      service et le serveur Edge de Cloudflare. La valeur par défaut
+      devrait convenir dans la plupart des cas.
+  additional_hosts:
+    name: Hôtes supplémentaires
+    description: >-
+      Définissez une liste d'hôtes supplémentaires devant être acheminés
+      par le tunnel Cloudflare.
+  post_quantum:
+    name: Utiliser la cryptographie post-quantique
+    description: >-
+      Cochez pour que le tunnel utilise la cryptographie post-quantique.
+      Avertissement : cela restreint également le tunnel au protocole QUIC,
+      ce qui pourrait entraîner des problèmes pour certains utilisateurs.
+  run_parameters:
+    name: Ajouter des paramètres d'exécution
+    description: >-
+      Possibilité d'ajouter des paramètres d'exécution à Cloudflared
+  catch_all_service:
+    name: Service Catch-All
+    description: >-
+      Définissez un service Catch-All qui sera appelé pour les services non configurés directement.
+  nginx_proxy_manager:
+    name: Activer le service Catch-All de Nginx-Proxy-Manager
+    description: >-
+      Définir le service Catch-All sur le module complémentaire "Nginx-Proxy-Manager Community App".
+  tunnel_token:
+    name: Token du tunnel Cloudflare
+    description: >-
+      Lorsque cette option est définie, toutes les autres options seront ignorées.
+      Utilisez cette option si vous avez configuré le tunnel via le tableau de bord Cloudflare.
+network:
+  36500/tcp: Interface web des métriques (36500/tcp)

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: Paulo Cloudflared
+url: https://github.com/PauloGoncalves86/app-cloudflared
+maintainer: Paulo Goncalves


### PR DESCRIPTION
# Proposed Changes

I added portuguese translations to cloudfared. I also ran the latest version of the cloudfare binary, 2026.8.3. Deployed to my home assistant as an additional tunnerl and it worked. No errors found, but I did not run the cloudfared test suite. 

I also changed the bashio addon config function as there was a deprecation error message, 

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
